### PR TITLE
Remove build from start

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "ember build && node api/server.js",
+    "start": "node api/server.js",
     "test": "ember test",
     "ember": "ember server --proxy http://localhost:4000",
     "build": "ember build",


### PR DESCRIPTION
When I deploy I'm getting the following error:

```
Updating service [default]...failed.
ERROR: (gcloud.app.deploy) Error Response: [9]
Application startup error:

> marchforscience@1.0.0 start /app
> ember build && node api/server.js

sh: 1: ember: not found
```

I tried adding ember-cli, then a bunch of the other ember deps from devDependencies, but I kept running into more and more errors. I might be missing something here, but `npm run deploy` already triggers a local build that I assume makes it into the image. Is there any need to run another `ember build` at `npm start`?